### PR TITLE
Allow specifying versions for plugin_gems

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ If the <code>[:scout][:key]</code> attribute is not provided or the scout execut
     </tr>
     <tr>
       <td>[:scout][:plugin_gems]</td>
-      <td>An Array of plugin gem dependencies to install. For example, you may want to install the <code>redis</code> gem if this node uses the redis plugin.</td>
+      <td>An Array of plugin gem dependencies to install. For example, you may want to install the <code>redis</code> gem if this node uses the redis plugin. Each entry in the array can be the name of a gem, or an array specifying the arguments required to install a specific version of a gem. For example, the following configuration will install the latest version of the <code>redis</code> gem: <code>node[:scout][:plugin_gems] = ['redis']</code> This configuration, on the other hand, will install version 3.2.1: <code>node[:scout][:plugin_gems] = [%w(redis --version 3.2.1)]</code></td>
       <td><code>nil</code></td>
     </tr>
     <tr>

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -96,7 +96,7 @@ end
   # wrap calls to the Scout library in ruby_block
   ruby_block "install a gem" do
     block do
-      Scout.install_gem(node, [gemname])
+      Scout.install_gem(node, Array(gemname))
     end
   end
 end


### PR DESCRIPTION
Previously, it was possible only to install the latest version of a gem. This PR allows specifying gem versions with the same array arguments expected by `Scout.install_gem`. Let me know if you'd prefer to implement this differently, and/or if you'd like the format to be documented in the README.

For example, the following node configuration will install the latest version of the docker-api gem:

    default[:scout][:plugin_gems] = ['docker-api']

This configuration, on the other hand, will install version 1.17.0

    default[:scout][:plugin_gems] = [%w(docker-api --version 1.17.0)]
