### PR TITLE
Stop trying to delete scout_shutdown if it does not exist

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -94,6 +94,7 @@ else
   bash "delete_scout_shutdown" do
     user "root"
     code "rm -f /etc/rc0.d/scout_shutdown"
+    only_if { File.exists?("/etc/rc0.d/scout_shutdown") }
   end
 end
 


### PR DESCRIPTION
Right now the recipe is reporting changes every time it is run. This adds a check that prevents that.