### PR TITLE
Fix missing scoutd user. Version bump.

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email  "supports@scoutapp.com"
 license           "Apache 2.0"
 description       "Installs and configures monitoring agent for scoutapp.com"
 long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version           "0.4"
+version           "0.5"
 
 %w[ubuntu debian redhat centos fedora scientific amazon].each do |os|
   supports os

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email  "supports@scoutapp.com"
 license           "Apache 2.0"
 description       "Installs and configures monitoring agent for scoutapp.com"
 long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version           "0.5"
+version           "0.6"
 
 %w[ubuntu debian redhat centos fedora scientific amazon].each do |os|
   supports os

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -33,6 +33,14 @@ when 'fedora'
   end
 end
 
+user 'scoutd' do
+  gid 'scoutd'
+  shell '/bin/bash'
+  home '/var/lib/scoutd'
+  system true
+  action :create
+end
+
 if node[:scout][:account_key]
   ENV['SCOUT_KEY'] = node[:scout][:account_key]
 


### PR DESCRIPTION
The scoutd user should preferably created on package install (doesn't happen with Debian package, not sure about other platforms). This means manual installs of the package won't work either. Version bump as well.