### PR TITLE
Comma-separated list of roles v array.

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ If the <code>[:scout][:account_key]</code> attribute is not provided the scout a
     </tr>
     <tr>
       <td>[:scout][:roles]</td>
-      <td>An Array of roles for this node. Roles are defined through Scout's UI.</td>
+      <td>An comma-separated list of roles for this node. Roles are defined through Scout's UI.</td>
       <td><code>nil</code></td>
     </tr>
     <tr>


### PR DESCRIPTION
The way the scoutd.yml template pulls values in by key causes it to write a literal array to the file like so: 

account_key: XXXXXXXXXXXXXX
hostname: host.domain.com
display_name: host.domain.com
environment: development
roles: ["role1", "role2"]

This causes the scoutd agent to improperly create a valid URL during runs and throw an error like so: 

/usr/local/rbenv/versions/2.1.1/lib/ruby/2.1.0/uri/generic.rb:1203:in `rescue in merge': bad URI(is not URI?): /clients/XXXXXXXXXXXXXXXXXXXX/ping.scout?roles=["role1", "role2"]&hostname=host.domain.com&env=development (URI::InvalidURIError)

Using a comma-separated list of roles fixes the issue. A validation to sanitize the array before writing or reading would fix as well, but this seems just as easy to change.