### PR TITLE
Fix scout dir mode

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -75,6 +75,7 @@ end
 directory "/var/lib/scoutd/.scout" do
   owner "scoutd"
   group "scoutd"
+  mode "0700"
   recursive true
 end
 


### PR DESCRIPTION
Chef was setting the mode to 000 for some reason.  Even if it was doing the dafault of 0777, it should not be world accessable per the default package install.