### PR TITLE
Add support for encrypted data bag usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,16 @@ If the <code>[:scout][:account_key]</code> attribute is not provided the scout a
       <td>If true, will run a shutdown script to remove the server from Scout when the server is shutdown.</td>
       <td><code>nil</code></td>
     </tr>
+    <tr>
+      <td>[:scout][:key][:bag_name]</td>
+      <td>If speficied, the account_key will be loaded from the given encrypted data bag. (Note: must also specifiy `[:scout][:key][:item_name]`)</td>
+      <td><code>nil</code></td>
+    </tr>
+    <tr>
+      <td>[:scout][:key][:item_name]</td>
+      <td>If speficied, the account_key will be loaded from the given encrypted data bag item under the `account_key` value in the bag. (Note: must also specifiy `[:scout][:key][:bag_name]`)</td>
+      <td><code>nil</code></td>
+    </tr>
   </tbody>
 </table>
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -20,3 +20,6 @@ default[:scout][:https_proxy] = nil
 default[:scout][:delete_on_shutdown] = false	# create rc.d script to remove the server from scout on shutdown
 default[:scout][:plugin_gems] = []   # list of gems to install to support plugins for role
 default[:scout][:plugin_properties] = {}
+
+default[:scout][:key][:bag_name] = nil
+default[:scout][:key][:item_name] = nil

--- a/libraries/scout.rb
+++ b/libraries/scout.rb
@@ -2,6 +2,17 @@
 include Chef::Mixin::ShellOut
 
 module Scout
+  def self.account_key(node)
+    if node[:scout][:key][:bag_name] && node[:scout][:key][:bag_name]
+      bag = Chef::EncryptedDataBagItem.load(node[:scout][:key][:bag_name], node[:scout][:key][:item_name])
+      bag['account_key']
+    elsif node[:scout][:account_key]
+      node[:scout][:account_key]
+    else
+      nil
+    end
+  end
+
   def self.gem_binary(node)
     ruby_path = node[:scout][:ruby_path] || 'ruby'
     if ruby_path.split(File::SEPARATOR).include?('wrappers') # if an RVM wrapper

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -33,7 +33,9 @@ when 'fedora'
   end
 end
 
-if node[:scout][:account_key]
+account_key = Scout.account_key(node)
+
+if account_key
   ENV['SCOUT_KEY'] = node[:scout][:account_key]
 
   package "scoutd" do
@@ -54,7 +56,7 @@ if node[:scout][:account_key]
     owner "scoutd"
     group "scoutd"
     variables :options => {
-      :account_key => node[:scout][:account_key],
+      :account_key => account_key,
       :hostname => node[:scout][:hostname],
       :display_name => node[:scout][:display_name],
       :log_file => node[:scout][:log_file],
@@ -69,7 +71,7 @@ if node[:scout][:account_key]
     notifies :restart, 'service[scout]', :delayed
   end
 else
-  Chef::Application.fatal! "The agent will not report to scoutapp.com as a key wasn't provided. Provide a [:scout][:account_key] attribute to complete the install."
+  Chef::Application.fatal! "The agent will not report to scoutapp.com as a key wasn't provided. Provide a [:scout][:account_key] or [:scout][:key][:bag_name] and [:scout][:key][:item_name] attribute to complete the install."
 end
 
 directory "/var/lib/scoutd/.scout" do


### PR DESCRIPTION
Allows the usage of the `[:scout][:account_key]` attribute or loading the key from an ecrypted data bag by specifying `[:scout][:key][:bag_name]` and `[:scout][:key][:item_name]`