### PR TITLE
Declare scout.yml as sensitive

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -66,6 +66,7 @@ if node[:scout][:account_key]
       :https_proxy => node[:scout][:https_proxy]
     }
     action :create
+    sensitive true
     notifies :restart, 'service[scout]', :delayed
   end
 else


### PR DESCRIPTION
The account key should not be exposed during a chef run