### PR TITLE
Allow disabling of scoutapp repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,11 @@ If the <code>[:scout][:account_key]</code> attribute is not provided the scout a
       <td><code>nil</code></td>
     </tr>
     <tr>
+      <td>[:scout][:enable_scoutapp_repo]</td>
+      <td>If true, will install the correct archive.scoutapp.com repository based on the hosts platform.  Only disable if you have the scoutd package hosted in a repository already installed on the host.</td>
+      <td><code>nil</code></td>
+    </tr>
+    <tr>
       <td>[:scout][:key][:bag_name]</td>
       <td>If speficied, the account_key will be loaded from the given encrypted data bag. (Note: must also specifiy `[:scout][:key][:item_name]`)</td>
       <td><code>nil</code></td>

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -20,6 +20,7 @@ default[:scout][:https_proxy] = nil
 default[:scout][:delete_on_shutdown] = false	# create rc.d script to remove the server from scout on shutdown
 default[:scout][:plugin_gems] = []   # list of gems to install to support plugins for role
 default[:scout][:plugin_properties] = {}
+default[:scout][:enable_scoutapp_repo] = true
 
 default[:scout][:key][:bag_name] = nil
 default[:scout][:key][:item_name] = nil

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -10,12 +10,14 @@ when 'ubuntu'
     key "https://archive.scoutapp.com/scout-archive.key"
     uri "http://archive.scoutapp.com"
     components ["ubuntu", "main"]
+    only_if { node[:scout][:enable_scoutapp_repo] }
   end
 when 'debian'
   apt_repository "scout" do
     key "https://archive.scoutapp.com/scout-archive.key"
     uri "http://archive.scoutapp.com"
     components [node[:lsb][:codename], "main"]
+    only_if { node[:scout][:enable_scoutapp_repo] }
   end
 when 'redhat', 'centos'
   yum_repository "scout" do
@@ -23,6 +25,7 @@ when 'redhat', 'centos'
     baseurl "http://archive.scoutapp.com/rhel/$releasever/main/$basearch/"
     gpgkey "https://archive.scoutapp.com/RPM-GPG-KEY-scout"
     action :create
+    only_if { node[:scout][:enable_scoutapp_repo] }
   end
 when 'fedora'
   yum_repository "scout" do
@@ -30,6 +33,7 @@ when 'fedora'
     baseurl "http://archive.scoutapp.com/fedora/$releasever/main/$basearch/"
     gpgkey "https://archive.scoutapp.com/RPM-GPG-KEY-scout"
     action :create
+    only_if { node[:scout][:enable_scoutapp_repo] }
   end
 end
 


### PR DESCRIPTION
This allows the installation of the scoutapp repo to be optional.  This is useful if the scoutd package is hosted in an interal repo for offline installation.