### PR TITLE
Prevent double reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The following platforms are supported by this cookbook, meaning that the recipes
 
 ## Required Attributes
 
-* [:scout][:account_key]
+### [:scout][:account_key]
 The agent requires a Scout account and the account's associated key. The key can be found in the account settings tab within the Scout UI or in the server setup instructions. The key looks like: `0mZ6BD9DR0qyZjaBLCPZZWkW3n2Wn7DV9xp5gQPs`
 Default value: `nil`
 
@@ -31,43 +31,43 @@ If the `[:scout][:account_key]` attribute is not provided the scout agent won't 
 
 ## Optional Attributes
 
-* [:scout][:hostname]
+### [:scout][:hostname]
 Optional hostname to uniquely identify this host to Scout.
 Default value: `nil`
 
-* [:scout][:display_name]
+### [:scout][:display_name]
 Optional name to display for this node within the Scout UI.
 Default value: `nil`
 
-* [:scout][:roles]
+### [:scout][:roles]
 An Array of roles for this node. Roles are defined through Scout's UI.
 Default value: `nil`
 
-* [:scout][:plugin_gems]
+### [:scout][:plugin_gems]
 An Array of plugin gem dependencies to install. For example, you may want to install the `redis` gem if this node uses the redis plugin. Each entry in the array can be the name of a gem, or an array specifying the arguments required to install a specific version of a gem. For example, the following configuration will install the latest version of the `redis` gem: `node[:scout][:plugin_gems] = ['redis']` This configuration, on the other hand, will install version 3.2.1: `node[:scout][:plugin_gems] = [%w(redis --version 3.2.1)]`
 Default value: `nil`
 
-* [:scout][:ruby_path]
+### [:scout][:ruby_path]
 The full path to a ruby executable or rvm wrapper which will run the Scout Ruby code and where the gem dependencies will be installed. If installing under a user based RVM install, you should also set the `:user` and `:group` options in `:gem_shell_opts` (see below). Example: `:rvm_wrapper => "/home/vagrant/.rvm/wrappers/ruby-1.9.3-p547"`
 Default value: `nil`
 
-* [:scout][:gem_shell_opts]
+### [:scout][:gem_shell_opts]
 A hash of valid [MixLib::ShellOut](https://github.com/opscode/mixlib-shellout) options. The recipe shells out to the `gem` command for installing gems. You can set things like the user/group to shell out as, shell environment variables such as $PATH, etc.
 Default value: `nil`
 
-* [:scout][:version]
+### [:scout][:version]
 Scout agent version to install. `nil` installs the latest release.
 Default value: `nil`
 
-* [:scout][:public_key]
+### [:scout][:public_key]
 If you use self-signed custom plugins, set this attribute to the public key value and it'll be installed on the node.
 Default value: `nil`
 
-* [:scout][:environment]
+### [:scout][:environment]
 The environment you would like this server to belong to, if you use environments. Environments are defined through scoutapp.com's web UI.
 Default value: `nil`
 
-* [:scout][:plugin_properties]
+### [:scout][:plugin_properties]
 Hash. Used to generate a plugins.properties file from encrypted data bags for secure lookups. E.g. "haproxy.password" => {"encrypted_data_bag" => "shared_passwords", "item" => "haproxy_stats", "key" => "password"} will create a plugins.properties entry with "haproxy.password=PASSWORD" where PASSWORD is an encrypted data bag item "haproxy_stats" in encrypted_data_bag "shared_passwords" with key "password".
 Default value: `{}`
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-
+# chef-scout
 
 Installs the agent for [Scout](http://scoutapp.com), a hosted server monitoring service. This recipe:
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,9 @@ The following platforms are supported by this cookbook, meaning that the recipes
 ## Required Attributes
 
 ### [:scout][:account_key]
+
 The agent requires a Scout account and the account's associated key. The key can be found in the account settings tab within the Scout UI or in the server setup instructions. The key looks like: `0mZ6BD9DR0qyZjaBLCPZZWkW3n2Wn7DV9xp5gQPs`
+
 Default value: `nil`
 
 If the `[:scout][:account_key]` attribute is not provided the scout agent won't be installed but all other parts of the recipe will execute.
@@ -32,43 +34,63 @@ If the `[:scout][:account_key]` attribute is not provided the scout agent won't 
 ## Optional Attributes
 
 ### [:scout][:hostname]
+
 Optional hostname to uniquely identify this host to Scout.
+
 Default value: `nil`
 
 ### [:scout][:display_name]
+
 Optional name to display for this node within the Scout UI.
+
 Default value: `nil`
 
 ### [:scout][:roles]
+
 An Array of roles for this node. Roles are defined through Scout's UI.
+
 Default value: `nil`
 
 ### [:scout][:plugin_gems]
+
 An Array of plugin gem dependencies to install. For example, you may want to install the `redis` gem if this node uses the redis plugin. Each entry in the array can be the name of a gem, or an array specifying the arguments required to install a specific version of a gem. For example, the following configuration will install the latest version of the `redis` gem: `node[:scout][:plugin_gems] = ['redis']` This configuration, on the other hand, will install version 3.2.1: `node[:scout][:plugin_gems] = [%w(redis --version 3.2.1)]`
+
 Default value: `nil`
 
 ### [:scout][:ruby_path]
+
 The full path to a ruby executable or rvm wrapper which will run the Scout Ruby code and where the gem dependencies will be installed. If installing under a user based RVM install, you should also set the `:user` and `:group` options in `:gem_shell_opts` (see below). Example: `:rvm_wrapper => "/home/vagrant/.rvm/wrappers/ruby-1.9.3-p547"`
+
 Default value: `nil`
 
 ### [:scout][:gem_shell_opts]
+
 A hash of valid [MixLib::ShellOut](https://github.com/opscode/mixlib-shellout) options. The recipe shells out to the `gem` command for installing gems. You can set things like the user/group to shell out as, shell environment variables such as $PATH, etc.
+
 Default value: `nil`
 
 ### [:scout][:version]
+
 Scout agent version to install. `nil` installs the latest release.
+
 Default value: `nil`
 
 ### [:scout][:public_key]
+
 If you use self-signed custom plugins, set this attribute to the public key value and it'll be installed on the node.
+
 Default value: `nil`
 
 ### [:scout][:environment]
+
 The environment you would like this server to belong to, if you use environments. Environments are defined through scoutapp.com's web UI.
+
 Default value: `nil`
 
 ### [:scout][:plugin_properties]
+
 Hash. Used to generate a plugins.properties file from encrypted data bags for secure lookups. E.g. "haproxy.password" => {"encrypted_data_bag" => "shared_passwords", "item" => "haproxy_stats", "key" => "password"} will create a plugins.properties entry with "haproxy.password=PASSWORD" where PASSWORD is an encrypted data bag item "haproxy_stats" in encrypted_data_bag "shared_passwords" with key "password".
+
 Default value: `{}`
 
 ## Questions?

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# chef-scout
+
 
 Installs the agent for [Scout](http://scoutapp.com), a hosted server monitoring service. This recipe:
 
@@ -23,90 +23,53 @@ The following platforms are supported by this cookbook, meaning that the recipes
 
 ## Required Attributes
 
-<table>
-  <thead>
-    <tr>
-      <th>Attribute</th>
-      <th>Description</th>
-      <th>Default Value</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td style="width:15%">[:scout][:account_key]</td>
-      <td>
-        The agent requires a Scout account and the account's associated key. The key can be found in the account settings tab within the Scout UI or in the server setup instructions. The key looks like:
-          <code>0mZ6BD9DR0qyZjaBLCPZZWkW3n2Wn7DV9xp5gQPs</code>
-      </td>
-      <td style="width:15%"><code>nil</code></td>
-    </tr>
-  </tbody>
-</table>
+* [:scout][:account_key]
+The agent requires a Scout account and the account's associated key. The key can be found in the account settings tab within the Scout UI or in the server setup instructions. The key looks like: `0mZ6BD9DR0qyZjaBLCPZZWkW3n2Wn7DV9xp5gQPs`
+Default value: `nil`
 
-If the <code>[:scout][:account_key]</code> attribute is not provided the scout agent won't be installed but all other parts of the recipe will execute.
+If the `[:scout][:account_key]` attribute is not provided the scout agent won't be installed but all other parts of the recipe will execute.
 
 ## Optional Attributes
 
-<table>
-  <thead>
-    <tr>
-      <th style="width:20%">Attribute</th>
-      <th>Description</th>
-      <th>Default Value</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>[:scout][:hostname]</td>
-      <td>Optional hostname to uniquely identify this host to Scout.</td>
-      <td><code>nil</code></td>
-    </tr>
-    <tr>
-      <td>[:scout][:display_name]</td>
-      <td>Optional name to display for this node within the Scout UI.</td>
-      <td><code>nil</code></td>
-    </tr>
-    <tr>
-      <td>[:scout][:roles]</td>
-      <td>An Array of roles for this node. Roles are defined through Scout's UI.</td>
-      <td><code>nil</code></td>
-    </tr>
-    <tr>
-      <td>[:scout][:plugin_gems]</td>
-      <td>An Array of plugin gem dependencies to install. For example, you may want to install the <code>redis</code> gem if this node uses the redis plugin. Each entry in the array can be the name of a gem, or an array specifying the arguments required to install a specific version of a gem. For example, the following configuration will install the latest version of the <code>redis</code> gem: <code>node[:scout][:plugin_gems] = ['redis']</code> This configuration, on the other hand, will install version 3.2.1: <code>node[:scout][:plugin_gems] = [%w(redis --version 3.2.1)]</code></td>
-      <td><code>nil</code></td>
-    </tr>
-    <tr>
-      <td>[:scout][:ruby_path]</td>
-      <td>The full path to a ruby executable or rvm wrapper which will run the Scout Ruby code and where the gem dependencies will be installed. If installing under a user based RVM install, you should also set the <code>:user</code> and <code>:group</code> options in <code>:gem_shell_opts</code> (see below). Example: <code>:rvm_wrapper => "/home/vagrant/.rvm/wrappers/ruby-1.9.3-p547"</code></td>
-      <td><code>nil</code></td>
-    </tr>
-    <tr>
-      <td>[:scout][:gem_shell_opts]</td>
-      <td>A hash of valid <a href="https://github.com/opscode/mixlib-shellout">Mixlib::ShellOut</a> options. The recipe shells out to the <code>gem</code> command for installing gems. You can set things like the user/group to shell out as, shell environment variables such as $PATH, etc.</td>
-      <td><code>nil</code></td>
-    </tr>
-    <tr>
-      <td>[:scout][:version]</td>
-      <td>Scout agent version to install. <code>nil</code> installs the latest release.</td>
-      <td><code>nil</code></td>
-    </tr>
-    <tr>
-      <td>[:scout][:public_key]</td>
-      <td>If you use self-signed custom plugins, set this attribute to the public key value and it'll be installed on the node.</td>
-      <td><code>nil</code></td>
-    </tr>
-    <tr>
-      <td>[:scout][:environment]</td>
-      <td>The environment you would like this server to belong to, if you use environments. Environments are defined through scoutapp.com's web UI.</td>
-      <td><code>nil</code></td>
-    </tr>
-    <tr>
-      <td>[:scout][:plugin_properties]</td>
-      <td>Hash. Used to generate a plugins.properties file from encrypted data bags for secure lookups. E.g. "haproxy.password" => {"encrypted_data_bag" => "shared_passwords", "item" => "haproxy_stats", "key" => "password"} will create a plugins.properties entry with "haproxy.password=PASSWORD" where PASSWORD is an encrypted data bag item "haproxy_stats" in encrypted_data_bag "shared_passwords" with key "password".</td>
-      <td><code>{}</code></td>
-  </tbody>
-</table>
+* [:scout][:hostname]
+Optional hostname to uniquely identify this host to Scout.
+Default value: `nil`
+
+* [:scout][:display_name]
+Optional name to display for this node within the Scout UI.
+Default value: `nil`
+
+* [:scout][:roles]
+An Array of roles for this node. Roles are defined through Scout's UI.
+Default value: `nil`
+
+* [:scout][:plugin_gems]
+An Array of plugin gem dependencies to install. For example, you may want to install the `redis` gem if this node uses the redis plugin. Each entry in the array can be the name of a gem, or an array specifying the arguments required to install a specific version of a gem. For example, the following configuration will install the latest version of the `redis` gem: `node[:scout][:plugin_gems] = ['redis']` This configuration, on the other hand, will install version 3.2.1: `node[:scout][:plugin_gems] = [%w(redis --version 3.2.1)]`
+Default value: `nil`
+
+* [:scout][:ruby_path]
+The full path to a ruby executable or rvm wrapper which will run the Scout Ruby code and where the gem dependencies will be installed. If installing under a user based RVM install, you should also set the `:user` and `:group` options in `:gem_shell_opts` (see below). Example: `:rvm_wrapper => "/home/vagrant/.rvm/wrappers/ruby-1.9.3-p547"`
+Default value: `nil`
+
+* [:scout][:gem_shell_opts]
+A hash of valid [MixLib::ShellOut](https://github.com/opscode/mixlib-shellout) options. The recipe shells out to the `gem` command for installing gems. You can set things like the user/group to shell out as, shell environment variables such as $PATH, etc.
+Default value: `nil`
+
+* [:scout][:version]
+Scout agent version to install. `nil` installs the latest release.
+Default value: `nil`
+
+* [:scout][:public_key]
+If you use self-signed custom plugins, set this attribute to the public key value and it'll be installed on the node.
+Default value: `nil`
+
+* [:scout][:environment]
+The environment you would like this server to belong to, if you use environments. Environments are defined through scoutapp.com's web UI.
+Default value: `nil`
+
+* [:scout][:plugin_properties]
+Hash. Used to generate a plugins.properties file from encrypted data bags for secure lookups. E.g. "haproxy.password" => {"encrypted_data_bag" => "shared_passwords", "item" => "haproxy_stats", "key" => "password"} will create a plugins.properties entry with "haproxy.password=PASSWORD" where PASSWORD is an encrypted data bag item "haproxy_stats" in encrypted_data_bag "shared_passwords" with key "password".
+Default value: `{}`
 
 ## Questions?
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -20,3 +20,4 @@ default[:scout][:https_proxy] = nil
 default[:scout][:delete_on_shutdown] = false	# create rc.d script to remove the server from scout on shutdown
 default[:scout][:plugin_gems] = []   # list of gems to install to support plugins for role
 default[:scout][:plugin_properties] = {}
+default[:scout][:groups] = [] # list of groups to add the scoutd user to

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -35,13 +35,22 @@ end
 
 if node[:scout][:account_key]
   ENV['SCOUT_KEY'] = node[:scout][:account_key]
+  ENV['SCOUT_HOSTNAME'] = node[:scout][:hostname]
+  ENV['SCOUT_DISPLAY_NAME'] = node[:scout][:display_name]
+  ENV['SCOUT_LOG_FILE'] = node[:scout][:log_file]
+  ENV['SCOUT_RUBY_PATH'] = node[:scout][:ruby_path]
+  ENV['SCOUT_ENVIRONMENT'] = node[:scout][:environment]
+  ENV['SCOUT_ROLES'] = node[:scout][:roles]
+  ENV['SCOUT_AGENT_DATA_FILE'] = node[:scout][:agent_data_file]
+  ENV['SCOUT_HTTP_PROXY'] = node[:scout][:http_proxy]
+  ENV['SCOUT_HTTPS_PROXY'] = node[:scout][:https_proxy]
 
   package "scoutd" do
     action :install
     version node[:scout][:version]
   end
 
-  node[:scout][:groups].each do |os_group|
+  Array(node[:scout][:groups]).each do |os_group|
     group os_group do
       action  :modify
       append  true
@@ -112,7 +121,7 @@ else
   end
 end
 
-(node[:scout][:plugin_gems] || []).each do |gemname|
+Array(node[:scout][:plugin_gems]).each do |gemname|
   # wrap calls to the Scout library in ruby_block
   ruby_block "install a gem" do
     block do

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -36,26 +36,6 @@ end
 if node[:scout][:account_key]
   ENV['SCOUT_KEY'] = node[:scout][:account_key]
 
-  template "/etc/scout/scoutd.yml" do
-    source "scoutd.yml.erb"
-    owner "scoutd"
-    group "scoutd"
-    variables :options => {
-      :account_key => node[:scout][:account_key],
-      :hostname => node[:scout][:hostname],
-      :display_name => node[:scout][:display_name],
-      :log_file => node[:scout][:log_file],
-      :ruby_path => node[:scout][:ruby_path],
-      :environment => node[:scout][:environment],
-      :roles => node[:scout][:roles],
-      :agent_data_file => node[:scout][:agent_data_file],
-      :http_proxy => node[:scout][:http_proxy],
-      :https_proxy => node[:scout][:https_proxy]
-    }
-    action :create
-    notifies :restart, 'service[scout]', :delayed
-  end
-
   package "scoutd" do
     action :install
     version node[:scout][:version]
@@ -76,6 +56,26 @@ if node[:scout][:account_key]
     action :nothing
     supports :restart => true
     restart_command "scoutctl restart"
+  end
+
+  template "/etc/scout/scoutd.yml" do
+    source "scoutd.yml.erb"
+    owner "scoutd"
+    group "scoutd"
+    variables :options => {
+      :account_key => node[:scout][:account_key],
+      :hostname => node[:scout][:hostname],
+      :display_name => node[:scout][:display_name],
+      :log_file => node[:scout][:log_file],
+      :ruby_path => node[:scout][:ruby_path],
+      :environment => node[:scout][:environment],
+      :roles => node[:scout][:roles],
+      :agent_data_file => node[:scout][:agent_data_file],
+      :http_proxy => node[:scout][:http_proxy],
+      :https_proxy => node[:scout][:https_proxy]
+    }
+    action :create
+    notifies :restart, 'service[scout]', :delayed
   end
 else
   Chef::Application.fatal! "The agent will not report to scoutapp.com as a key wasn't provided. Provide a [:scout][:account_key] attribute to complete the install."


### PR DESCRIPTION
* Adds config options as environment vars for the initial checkin
* Reformats the README in pure Markdown to display correctly in Chef supermarket
* Adds optional groups for the scoutd user