### PR TITLE
Move the notifies directive into the group resource

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -62,8 +62,8 @@ if account_key
       append  true
       members 'scoutd'
       system  true
+      notifies :restart, 'service[scout]', :delayed
     end
-    notifies :restart, 'service[scout]', :delayed
   end
 
   # We only need the scout service definition so that we can


### PR DESCRIPTION
When I `include_recipe 'scout'`, it fails to compile with the following recipe compile error:

```
NoMethodError
-------------
No resource or method named `notifies' for `Chef::Recipe "default"'
```

I think the dangling `notifies` just needs to be moved up into the `group` resource above it. This patch fixes the issue for me.