### PR TITLE
Allow string values in plugin_properties hash

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Default value: `nil`
 
 ### [:scout][:plugin_properties]
 
-Hash. Used to generate a plugins.properties file from encrypted data bags for secure lookups. E.g. "haproxy.password" => {"encrypted_data_bag" => "shared_passwords", "item" => "haproxy_stats", "key" => "password"} will create a plugins.properties entry with "haproxy.password=PASSWORD" where PASSWORD is an encrypted data bag item "haproxy_stats" in encrypted_data_bag "shared_passwords" with key "password".
+Hash. Used to generate a plugins.properties file from string values or encrypted data bag items. For example, "haproxy.password" => "foobar" will create an entry "haproxy.password=foobar" in the plugins.properties file. Alternatively, "haproxy.password" => {"encrypted_data_bag" => "shared_passwords", "item" => "haproxy_stats", "key" => "password"} will create a plugins.properties entry with "haproxy.password=PASSWORD" where PASSWORD is an encrypted data bag item "haproxy_stats" in encrypted_data_bag "shared_passwords" with key "password".
 
 Default value: `{}`
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -147,8 +147,12 @@ template "/var/lib/scoutd/.scout/plugins.properties" do
   group "scoutd"
   variables lazy {
     plugin_properties = {}
-    node['scout']['plugin_properties'].each do |property, lookup_hash|
-      plugin_properties[property] = Chef::EncryptedDataBagItem.load(lookup_hash[:encrypted_data_bag], lookup_hash[:item])[lookup_hash[:key]]
+    node['scout']['plugin_properties'].each do |property, value|
+      if value.instance_of?(String)
+        plugin_properties[property] = value
+      else
+        plugin_properties[property] = Chef::EncryptedDataBagItem.load(value[:encrypted_data_bag], value[:item])[value[:key]]
+      end
     end
     {
       :plugin_properties => plugin_properties


### PR DESCRIPTION
When installing scoutd with Chef under AWS's Opsworks, data bag support is limited and parameters that we'd like to put in the plugins.properties file need to be passed via Opsworks's "custom JSON" hashes, which end up in the chef node. This patch allows plugins.properties to be initialized either via data bags (the current behavior) or via raw strings.