### PR TITLE
/etc/init.d/scout

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -66,6 +66,10 @@ if account_key
     end
   end
 
+  link '/etc/init.d/scout' do
+    to '/usr/sbin/scoutctl'
+  end
+
   # We only need the scout service definition so that we can
   # restart scout after we configure scoutd.yml
   service "scout" do


### PR DESCRIPTION
Otherwise restarting service `scout` will fail (at least on Amazon Linux) with the following message:

```
================================================================================
Error executing action `restart` on resource 'service[scout]'
================================================================================
 
 
Chef::Exceptions::Service
-------------------------
service[scout]: unable to locate the init.d script!
 
 
Resource Declaration:
---------------------
# In [...]/cookbooks/scout/recipes/default.rb
 
87:   service "scout" do
88:     action :nothing
89:     supports :restart => true
90:     restart_command "scoutctl restart"
91:   end
92: 
```