### PR TITLE
pulling the ubuntu distribution out of apt_repository "components"

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -9,7 +9,8 @@ when 'ubuntu'
   apt_repository "scout" do
     key "https://archive.scoutapp.com/scout-archive.key"
     uri "http://archive.scoutapp.com"
-    components ["ubuntu", "main"]
+    components [ "main" ]
+    distribution "ubuntu"
     only_if { node[:scout][:repo][:enable] }
   end
 when 'debian'


### PR DESCRIPTION
This apparently used to not be an issue but with a recent change in chef it no longer works. Proper separation of distribution from components is required.

This addresses a problem I emailed support about last week.